### PR TITLE
Update readme.md - adjusted version for az modules

### DIFF
--- a/lab-guides/01a-DeployAzureStackHCICluster-CloudBasedDeployment/readme.md
+++ b/lab-guides/01a-DeployAzureStackHCICluster-CloudBasedDeployment/readme.md
@@ -456,12 +456,12 @@ Invoke-Command -ComputerName $Servers -ScriptBlock {
 
 #make sure az.accounts module is installed on nodes
 Invoke-Command -ComputerName $Servers -ScriptBlock {
-    Install-Module -Name az.accounts -RequiredVersion 2.13.2 -Force
+    Install-Module -Name az.accounts -RequiredVersion 3.0.0 -Force
 } -Credential $Credentials
 
 #make sure az.accounts module is installed on nodes
 Invoke-Command -ComputerName $Servers -ScriptBlock {
-    Install-Module -Name Az.ConnectedMachine -RequiredVersion 0.5.2 -Force
+    Install-Module -Name Az.ConnectedMachine -RequiredVersion 0.8.0 -Force
 } -Credential $Credentials
 
 ```


### PR DESCRIPTION
MSFT has adjusted the required versions for >2408
the instructions would override the apparently updated modules in the latest 2408 ISO. https://learn.microsoft.com/en-us/azure-stack/hci/deploy/deployment-arc-register-server-permissions?tabs=powershell#register-servers-with-azure-arc