### PR TITLE
Update readme.md - updated 23H2 virtual requirements for LabConfig WebUI

### DIFF
--- a/lab-guides/01b-DeployAzureStackHCICluster-WebUI/readme.md
+++ b/lab-guides/01b-DeployAzureStackHCICluster-WebUI/readme.md
@@ -34,7 +34,7 @@ $LabConfig=@{AllowedVLANs="1-10,711-719" ; DomainAdminName='LabAdmin'; AdminPass
 
 #Azure Stack HCI 23H2
 #labconfig will not domain join VMs
-1..2 | ForEach-Object {$LABConfig.VMs += @{ VMName = "LTPNode$_" ; Configuration = 'S2D' ; ParentVHD = 'AzSHCI23H2_G2_Preview.vhdx' ; HDDNumber = 4 ; HDDSize= 2TB ; MemoryStartupBytes= 20GB; VMProcessorCount="MAX" ; vTPM=$true ; Unattend="NoDjoin" ; NestedVirt=$true }}
+1..2 | ForEach-Object {$LABConfig.VMs += @{ VMName = "LTPNode$_" ; Configuration = 'S2D' ; ParentVHD = 'AzSHCI23H2_G2.vhdx' ; HDDNumber = 4 ; HDDSize= 1TB ; MemoryStartupBytes= 24GB; VMProcessorCount="MAX" ; vTPM=$true ; Unattend="NoDjoin" ; NestedVirt=$true }}
 
 #Windows Admin Center in GW mode
 $LabConfig.VMs += @{ VMName = 'WACGW' ; ParentVHD = 'Win2025Core_G2.vhdx'; MGMTNICs=1}


### PR DESCRIPTION
Updated Startup RAM from 20 GB to 24 GB
Updated Data Disk Dize from 2 TB to 1 TB

See: https://learn.microsoft.com/en-us/azure-stack/hci/deploy/deployment-virtual#virtual-host-requirements


Updated Name of ParentVHD, as preview 23H2 is no longer required with the updated 2408 ISO. See: https://learn.microsoft.com/en-us/azure-stack/hci/deploy/deployment-arc-register-local-ui

I have deliberately not changed the number of data disks as I believe the docs are not correct in this point, disagreeing with the system requirements in HW. See: https://github.com/MicrosoftDocs/azure-stack-docs/pull/3340