### PR TITLE
Update readme.md - updated 23H2 virtual requirements for LabConfig

### DIFF
--- a/lab-guides/01a-DeployAzureStackHCICluster-CloudBasedDeployment/readme.md
+++ b/lab-guides/01a-DeployAzureStackHCICluster-CloudBasedDeployment/readme.md
@@ -49,7 +49,7 @@ $LabConfig=@{AllowedVLANs="1-10,711-719" ; DomainAdminName='LabAdmin'; AdminPass
 
 #Azure Stack HCI 23H2
 #labconfig will not domain join VMs
-1..2 | ForEach-Object {$LABConfig.VMs += @{ VMName = "ASNode$_" ; Configuration = 'S2D' ; ParentVHD = 'AzSHCI23H2_G2.vhdx' ; HDDNumber = 4 ; HDDSize= 2TB ; MemoryStartupBytes= 20GB; VMProcessorCount="MAX" ; vTPM=$true ; Unattend="NoDjoin" ; NestedVirt=$true }}
+1..2 | ForEach-Object {$LABConfig.VMs += @{ VMName = "ASNode$_" ; Configuration = 'S2D' ; ParentVHD = 'AzSHCI23H2_G2.vhdx' ; HDDNumber = 4 ; HDDSize= 1TB ; MemoryStartupBytes= 24GB; VMProcessorCount="MAX" ; vTPM=$true ; Unattend="NoDjoin" ; NestedVirt=$true }}
 
 #Windows Admin Center in GW mode
 $LabConfig.VMs += @{ VMName = 'WACGW' ; ParentVHD = 'Win2022Core_G2.vhdx'; MGMTNICs=1}


### PR DESCRIPTION
Updated Startup RAM from 20 GB to 24 GB
Updated Data Disk Dize from 2 TB to 1 TB

See: https://learn.microsoft.com/en-us/azure-stack/hci/deploy/deployment-virtual#virtual-host-requirements


I have deliberately not changed the number of data disks as I believe the docs are not correct in this point, disagreeing with the system requirements in HW. See: https://github.com/MicrosoftDocs/azure-stack-docs/pull/3340