### PR TITLE
Update readme.md - variables block on the top

### DIFF
--- a/lab-guides/01-AzureLocalCloudDeployment/readme.md
+++ b/lab-guides/01-AzureLocalCloudDeployment/readme.md
@@ -126,6 +126,32 @@ Restart-Computer
 
 ![](./media/hvconnect01.png)
 
+### Define your lab variables
+
+```PowerShell
+#variables for Azure Local cluster nodes
+$Servers="ALNode1","ALNode2"
+$UserName="Administrator"
+$Password="LS1setup!"
+$SecuredPassword = ConvertTo-SecureString $password -AsPlainText -Force
+$Credentials= New-Object System.Management.Automation.PSCredential ($UserName,$SecuredPassword)
+
+#variables for AD Preparation 
+$AsHCIOUName="OU=ALClus01,DC=Corp,DC=contoso,DC=com"
+$LCMUserName="ALClus01-LCMUser"
+$LCMPassword="LS1setup!LS1setup!"
+
+#Create LCM credentials
+$SecuredPassword = ConvertTo-SecureString $LCMPassword -AsPlainText -Force
+$LCMCredentials= New-Object System.Management.Automation.PSCredential ($LCMUserName,$SecuredPassword)
+
+#Arc Gateway variables
+$GatewayName="ALClus01-ArcGW"
+$ResourceGroupName="ALClus01-RG"
+$Location="eastus" #list of supported regions: https://learn.microsoft.com/en-us/azure/azure-local/concepts/system-requirements-23h2?view=azloc-2507&tabs=azure-public#azure-requirements
+```
+
+
 ### Task01 - Validate connectivity to servers
 
 #### Step 1 Test name resolution works with simple ping
@@ -139,7 +165,6 @@ Notice, that host is replying. Latest image Azure Local already allows ICMP pack
 #### Step 2 Check WinRM connectivity
 
 ```PowerShell
-$Servers="ALNode1","ALNode2"
 foreach ($Server in $Servers){
     Test-NetConnection -ComputerName $Server -CommonTCPPort WINRM
 }
@@ -161,11 +186,6 @@ Get-NetFirewallRule -Name WINRM-HTTP-In-TCP-PUBLIC | Get-NetFirewallAddressFilte
 #### Step 3 Connect to servers using WinRM
 
 ```PowerShell
-$Servers="ALNode1","ALNode2"
-$UserName="Administrator"
-$Password="LS1setup!"
-$SecuredPassword = ConvertTo-SecureString $password -AsPlainText -Force
-$Credentials= New-Object System.Management.Automation.PSCredential ($UserName,$SecuredPassword)
 
 #configure trusted hosts to be able to communicate with servers
 $TrustedHosts=@()
@@ -464,13 +484,6 @@ Simply run the following PowerShell script to create objects
 > LCM = LifeCycle Management account. Account that will be used to domain join machines and create CAU account.
 
 ```PowerShell
-$AsHCIOUName="OU=ALClus01,DC=Corp,DC=contoso,DC=com"
-$LCMUserName="ALClus01-LCMUser"
-$LCMPassword="LS1setup!LS1setup!"
-#Create LCM credentials
-$SecuredPassword = ConvertTo-SecureString $LCMPassword -AsPlainText -Force
-$LCMCredentials= New-Object System.Management.Automation.PSCredential ($LCMUserName,$SecuredPassword)
-
 #create objects for Azure Local in Active Directory
     #install posh module for prestaging Active Directory
     Install-PackageProvider -Name NuGet -Force
@@ -495,10 +508,6 @@ $LCMCredentials= New-Object System.Management.Automation.PSCredential ($LCMUserN
 Following script will simply create Resource Group and Arc Gateway (optional).
 
 ```PowerShell
-$GatewayName="ALClus01-ArcGW"
-$ResourceGroupName="ALClus01-RG"
-$Location="eastus" #list of supported regions: https://learn.microsoft.com/en-us/azure/azure-local/concepts/system-requirements-23h2?view=azloc-2507&tabs=azure-public#azure-requirements
-
 #login to azure
     #download Azure module
     Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
@@ -517,7 +526,7 @@ $Location="eastus" #list of supported regions: https://learn.microsoft.com/en-us
         }
 
     #create resource group
-        if (-not(Get-AzResourceGroup -Name $ResourceGroupName -ErrorAction Ignore)){
+        if (-not(Get-AzResourceGroup -Name  -ErrorAction Ignore)){
             New-AzResourceGroup -Name $ResourceGroupName -Location $location
         }
 #region (Optional) configure Arc Gateway
@@ -598,6 +607,7 @@ Register-AzResourceProvider -ProviderNamespace "Microsoft.Insights"
     $id = (Get-AzContext).Account.Id
     $Cloud="AzureCloud"
 
+<# no longer needed
     #check if token is plaintext (older module version outputs plaintext, version 5 outputs secure string)
     # Check if the token is a SecureString
     if ($armtoken -is [System.Security.SecureString]) {
@@ -607,6 +617,7 @@ Register-AzResourceProvider -ProviderNamespace "Microsoft.Insights"
     }else {
         Write-Output "Token is already plaintext."
     }
+#>
 
 <# no longer needed
     #check if ImageCustomizationScheduledTask is not in disabled state (if it's "ready", run it) - will be fixed in 2506

--- a/lab-guides/01-AzureLocalCloudDeployment/readme.md
+++ b/lab-guides/01-AzureLocalCloudDeployment/readme.md
@@ -526,7 +526,7 @@ Following script will simply create Resource Group and Arc Gateway (optional).
         }
 
     #create resource group
-        if (-not(Get-AzResourceGroup -Name  -ErrorAction Ignore)){
+        if (-not(Get-AzResourceGroup -Name $ResourceGroupName -ErrorAction Ignore)){
             New-AzResourceGroup -Name $ResourceGroupName -Location $location
         }
 #region (Optional) configure Arc Gateway

--- a/lab-guides/01-AzureLocalCloudDeployment/readme.md
+++ b/lab-guides/01-AzureLocalCloudDeployment/readme.md
@@ -145,10 +145,14 @@ $LCMPassword="LS1setup!LS1setup!"
 $SecuredPassword = ConvertTo-SecureString $LCMPassword -AsPlainText -Force
 $LCMCredentials= New-Object System.Management.Automation.PSCredential ($LCMUserName,$SecuredPassword)
 
-#Arc Gateway variables
+#variables for Arc Gateway and Azure ResourceGroup and Location
 $GatewayName="ALClus01-ArcGW"
 $ResourceGroupName="ALClus01-RG"
 $Location="eastus" #list of supported regions: https://learn.microsoft.com/en-us/azure/azure-local/concepts/system-requirements-23h2?view=azloc-2507&tabs=azure-public#azure-requirements
+
+#Variable for NTP time source for Azure Local nodes
+$NTPServer="DC.corp.contoso.com"  
+
 ```
 
 
@@ -708,8 +712,6 @@ In MSLab is DHCP enabled. This script will make sure there's just one GW and DHC
 This script simply tests if offset between management machine and any of the servers is greater than 2s. If so, it will configure NTP server. Just provide your NTP server (you can use domain controller)
 
 ```PowerShell
-$NTPServer="DC.corp.contoso.com"  
-
 #test if there is an time offset on servers
 Foreach ($Server in $Servers){
     $localtime=get-date


### PR DESCRIPTION
I found that if you use this to deploy several labs, you need to more quickly derive the variables used for this lab.

I have moved all required variables to the top that require adjustment and from here they can be used on the management host. Hope you appreciate this change.

In addition, this PR removes duplicates of $servers variable used during the lab.